### PR TITLE
Fix development color mode preference

### DIFF
--- a/res/values-bg/cm_strings.xml
+++ b/res/values-bg/cm_strings.xml
@@ -24,6 +24,10 @@
     <string name="berry_black_theme_title">Натурално черно</string>
     <string name="berry_black_theme_summary">Натурален черен фон за тъмна тема</string>
     <string name="lineagelicense_title">LineageOS правна информация</string>
+    <string name="show_dev_countdown_cm">{count, plural,
+      =1      {Остава # стъпка до активиране настройките за разработчици.}
+      other   {Остават # стъпки до активиране настройките за разработчици.}
+    }</string>
     <string name="show_dev_on_cm">Включихте менюто \"Опции на програмиста\"!</string>
     <string name="show_dev_already_cm">Няма нужда, вече сте включили менюто Опции на програмиста.</string>
     <string name="status_bar_double_tap_to_sleep_title">Натиснете, за заспиване</string>
@@ -85,4 +89,22 @@
     <string name="fast_charging_title">Бързо зареждане</string>
     <string name="fast_charging_summary">Деактивирайте, за да намалите топлината, произведена от устройството по време на зареждане или да удължите живота на батерията</string>
     <string name="storage_warning_internal">Предупреждение: Тази опция може да не работи правилно или доведе до загуба на данни и затова не се препоръчва!</string>
+    <string name="assisted_gps">Използване на асистиран GPS</string>
+    <string name="assisted_gps_summary">Изтегли помощна сателитна информация от интернет, за да повиши продуктивността на GPS при стартиране. За спешни обаждания, асистираният GPS е винаги позволен.</string>
+    <string name="battery_technology">Технология</string>
+    <string name="battery_health">Състояние</string>
+    <string name="battery_health_good">Добро</string>
+    <string name="battery_health_overheat">Прегряване</string>
+    <string name="battery_health_dead">Дефектна</string>
+    <string name="battery_health_over_voltage">Пренапрежение</string>
+    <string name="battery_health_unspecified_failure">Неопределен проблем</string>
+    <string name="battery_health_cold">Студена</string>
+    <string name="battery_health_unknown">Неизвестно</string>
+    <string name="battery_temperature">Температура</string>
+    <string name="battery_voltage">Напрежение</string>
+    <string name="battery_charge_counter_summary">%1$d mAh</string>
+    <string name="battery_design_capacity">Фабричен капацитет</string>
+    <string name="battery_design_capacity_summary">%1$d mAh</string>
+    <string name="battery_maximum_capacity">Максимален капацитет</string>
+    <string name="battery_maximum_capacity_summary">%1$d mAh (%2$d%%)</string>
 </resources>

--- a/res/values-ta/cm_strings.xml
+++ b/res/values-ta/cm_strings.xml
@@ -64,6 +64,8 @@
     <string name="unlock_scramble_pin_layout_title">கலரீடு தளவமைப்பு</string>
     <string name="unlock_scramble_pin_layout_summary">கருவியைத் திறக்கும்போது PIN தளவமைப்பைக் கலரீடுக</string>
     <string name="proximity_wake_title">தற்செயலான விழித்தலை தடு</string>
+    <string name="touchscreen_gesture_settings_title">தொடுதிரை மெய்ப்பாடுகள்</string>
+    <string name="touchscreen_gesture_settings_summary">விரைவான செயல்களுக்காகப் பல்வேறு தொடுதிரை மெய்ப்பாடுகளை இயற்றுக</string>
     <string name="touchscreen_hovering_title">தொடல்திறைக்கு மேல் நகர்தல்</string>
     <string name="touchscreen_hovering_summary">வலைதள உலாவிகள், ரிமோட்-டெஸ்க்டாப்புகள் உள்ளிட்டவற்றில் மவுஸ் போன்று நீங்கள் திரையின் மீது உலாவ உங்களை அனுமதிக்கிறது</string>
     <string name="wake_when_plugged_or_unplugged_title">பிளக் செய்தால் விழி</string>

--- a/src/com/android/settings/development/ColorModePreference.java
+++ b/src/com/android/settings/development/ColorModePreference.java
@@ -24,14 +24,14 @@ import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.Display;
 
-import androidx.preference.TwoStatePreference;
+import androidx.preference.SwitchPreferenceCompat;
 
 import com.android.settingslib.R;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class ColorModePreference extends TwoStatePreference implements DisplayListener {
+public class ColorModePreference extends SwitchPreferenceCompat implements DisplayListener {
 
     private DisplayManager mDisplayManager;
     private Display mDisplay;


### PR DESCRIPTION
This is a sed gone wrong.
    It was unintentionally changed in 15ca95a31b51682f868e486e9f07c64d785c3f4b
    which broke functionality.
    
    Change it to a SwitchPreferenceCompat instead of changing it back
    to a SwitchPreference, as all the other preferences in the
    development section are one as well.
    
    Change-Id: Id276d3b67c103b83ba01a69ff2991246c69efc69
    Signed-off-by: Alexander Martinz <amartinz@shiftphones.com>